### PR TITLE
Read from /sys/class directly

### DIFF
--- a/batnotify
+++ b/batnotify
@@ -4,15 +4,14 @@ if [[ -z "${SAFE_BATTERY_LEVEL}" ]]; then
 	SAFE_BATTERY_LEVEL=15
 fi
 
-if [[ -z "${NOTIF_TIMEOUT}" ]]; then
-	NOTIF_TIMEOUT=3000
+if [[ -n "${NOTIF_TIMEOUT_MILLIS}" ]]; then
+	OPT_NOTIF_TIMEOUT_MILLIS="-t ${NOTIF_TIMEOUT_MILLIS}"
 fi
 
-info=$(upower -i $(upower -e | grep 'BAT') | grep -E "state|to\ full|percentage")
-state=$(echo $info | cut -d " " -f2)
-percentage=$(echo $info | awk '{print $NF}' | cut -d "%" -f1)
+status=$(</sys/class/power_supply/BAT0/status)
+capacity=$(</sys/class/power_supply/BAT0/capacity)
 
-if [[ $percentage -lt $SAFE_BATTERY_LEVEL && $state == "discharging" ]]; then
-  notify-send -t $NOTIF_TIMEOUT -u critical "Battery level critical!" \
-	  "Connect Charger  <br />Battery level is at $percentage%"
+if [[ $capacity -lt $SAFE_BATTERY_LEVEL && $status == "Discharging" ]]; then
+  notify-send $OPT_NOTIF_TIMEOUT -u critical "Battery level critical!" \
+	  "Connect Charger  <br />Battery level is at ${capacity}%"
 fi


### PR DESCRIPTION
Also allow for no timeout.

Please take this PR as a suggestion. Feel free to close it.

Some people also have mentioned [pweralertd](https://sr.ht/~kennylevinsen/poweralertd/) as an alternative. You could also mention it in the README.